### PR TITLE
데스크탑, 태블릿 뷰에서 배너에 의해 메인 컨텐츠가 가려지는 이슈

### DIFF
--- a/src/views/MainPage/MainPage.module.scss
+++ b/src/views/MainPage/MainPage.module.scss
@@ -2,6 +2,8 @@
 @import 'mixin';
 
 .Container {
+  padding-top: 128px;
+
   @include mobile {
     padding-top: 80px;
   }


### PR DESCRIPTION
## 변경사항
- 769 ~ 960px 뷰에서 상단 배너에 의해 메인 컨텐츠 영역이 가려지는 현상이 있어 해당 뷰포트에서 Main영역 padding-top: 배너 높이 만큼의 속성을 주었습니다.
- 데스크탑에서도 세로 뷰포트가 조금이라도 줄어들면 같은 증상이 일어나 배너 높이 만큼 속성을 주었습니다.