### PR TITLE
Refactor: 12기 모집기간 종료로 띠배너 UI 제거

### DIFF
--- a/src/views/MainPage/Header/index.tsx
+++ b/src/views/MainPage/Header/index.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import RecruitingBanner from '@views/MainPage/RecruitingBanner';
 import { useWindowScroll } from '@utils/hooks/useWindow';
 import { motion } from 'framer-motion';
 import cc from 'classcat';
@@ -58,7 +57,6 @@ const Header = () => {
           <a className={ S.MenuButton } href='#' onClick={ (event) => onNavigateTo(event, 'joinus') }>JOIN US! →</a>
         </div>
       </div>
-      <RecruitingBanner/>
     </motion.div>
   )
 }

--- a/src/views/MainPage/HeroSection/styles.module.scss
+++ b/src/views/MainPage/HeroSection/styles.module.scss
@@ -77,7 +77,7 @@
 
 .Lottie {
   width: 100%;
-  height: 95vh;
+  height: 100vh;
   display: block;
 
   @include iphone {
@@ -87,7 +87,7 @@
 
 .LottieMobile {
   width: 100%;
-  height: 90%;
+  height: 100%;
   display: none;
 
   @include iphone {

--- a/src/views/MainPage/MainPage.module.scss
+++ b/src/views/MainPage/MainPage.module.scss
@@ -2,9 +2,4 @@
 @import 'mixin';
 
 .Container {
-  padding-top: 5vh;
-
-  @include tablet {
-    padding-top: 10%;
-  }
 }

--- a/src/views/MainPage/RecruitingBanner/index.tsx
+++ b/src/views/MainPage/RecruitingBanner/index.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import S from './styles.module.scss';
 import RECRUIT_ARROW from '@resources/svg/recruit_arrow.svg';
 
+// TODO:(하준) 현재 아무곳에서도 사용하지 않고 있음 13기때 배너를 이용할거라면 리팩토링 후 사용
 const RecruitingBanner:React.FC = () => {
   return (
     <div className={S.Container}>
@@ -16,4 +17,4 @@ const RecruitingBanner:React.FC = () => {
   )
 }
 
-export default RecruitingBanner
+export default RecruitingBanner;


### PR DESCRIPTION
## 변경사항
- 12기 모집 종료로 인해 기존에 헤더에 붙어있던 모집 홍보 배너를 제거해줍니다.