### PR TITLE
iOS safari 환경에서 sticky로 인한 레이아웃 버그 수정

### DIFF
--- a/src/components/Section/Section.module.scss
+++ b/src/components/Section/Section.module.scss
@@ -1,5 +1,5 @@
-@import "variables";
-@import "mixin";
+@import 'variables';
+@import 'mixin';
 
 .Container {
   width: 100%;
@@ -18,7 +18,6 @@
   width: 100%;
   padding: 160px 0 120px;
 
-
   @include mobile {
     padding: 100px 0 80px;
   }
@@ -33,7 +32,6 @@
   flex-direction: column;
   justify-content: center;
   align-content: center;
-  position: -webkit-sticky;
   background: $page-bg-first-color;
   z-index: 10;
 

--- a/src/components/Section/Section.tsx
+++ b/src/components/Section/Section.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import cc from 'classcat';
-import S from './Section.module.scss';
 import { motion } from 'framer-motion';
+import S from './Section.module.scss';
 
 interface Props {
   sectionId: string;
@@ -18,27 +18,18 @@ const Section: React.FC<Props> = ({
   hasPadding = true,
   children,
 }: Props) => (
-  <motion.section
-    id={ sectionId }
-    className={ hasPadding ? S.Container : S.ContainerWithoutPadding }
-  >
-    {
-      title && (
-        <div className={ cc([S.HeaderSection, { [S.AddPadding]: !hasPadding }])  }>
-          <h2
-            className={ S.Title }
-            data-aos='fade-up'
-            data-aos-duration='600'
-          > { title } </h2>
-          <p
-            className={ S.SubTitle }
-            data-aos='fade-up'
-            data-aos-duration='800'
-          > { subTitle } </p>
-        </div>
-      )
-    }
-    { children }
+  <motion.section id={sectionId} className={hasPadding ? S.Container : S.ContainerWithoutPadding}>
+    {title && (
+      <div className={cc([S.HeaderSection, { [S.AddPadding]: !hasPadding }])}>
+        <h2 className={S.Title} data-aos="fade-up" data-aos-duration="600">
+          {title}
+        </h2>
+        <p className={S.SubTitle} data-aos="fade-up" data-aos-duration="800">
+          {subTitle}
+        </p>
+      </div>
+    )}
+    {children}
   </motion.section>
 );
 


### PR DESCRIPTION
## 변경사항
- Section 컴포넌트 내부 `S.HeaderSection` 스타일이 적용된 요소들에 `position: webkit-sticky`가 적용되어 있어 일어나는 레이아웃 버그를 해당 스타일 로직을 제거하여 해결해주었습니다.

### 기존
![IMG_4379](https://user-images.githubusercontent.com/71176945/206613760-bb4c9d1c-3d5d-43d2-99ab-d6d1aab6f216.PNG)

### fix 후
![IMG_4380](https://user-images.githubusercontent.com/71176945/206613795-364048a7-1f74-4dea-aab4-74404a6d02e4.PNG)


> eslint autofix 동작으로 버그fix와 관련없는 코드의 변경도 포함되어 있습니다.