### PR TITLE
PartnershipSection타이틀 중에서 매시업 -> 매쉬업으로 수정

### DIFF
--- a/src/views/MainPage/PartnershipSection/index.tsx
+++ b/src/views/MainPage/PartnershipSection/index.tsx
@@ -26,8 +26,8 @@ const PartnershipSection: React.FC<Props> = () => {
   return (
     <Section
       sectionId="partnership"
-      title="매시업과 함께 하는 기업"
-      subTitle="매시업과 함께하는 파트너 후원사를 소개합니다."
+      title="매쉬업과 함께 하는 기업"
+      subTitle="매쉬업과 함께하는 파트너 후원사를 소개합니다."
     >
       <div className={S.partnershipContainer}>
         {partners.map(({ name, image, url }, index) => {


### PR DESCRIPTION
## 변경사항
- PartnershipSection을 제외한 타 section들에 사용된 워딩이 매쉬업이기 떄문에 일관성을 위해 수정해주었습니다.