### PR TITLE
폰트 로딩부를 SSR에 포함되는 next/head에서 document/head로 이동

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -48,21 +48,6 @@ const App = ({ Component, pageProps }) => {
           content="매쉬업은 개발, 디자인에 관심과 열정이 있는 사람들이 모인 단체로 Product Design, Android, iOS, Node, Spring, Web 총 6개의 팀으로 구성되어 있습니다. 매쉬업에서는 전체모임의 세미나 및 네트워킹을 진행하고 있으며, 이를 통하여 개인의 전문역량과 협업능력을 증대시키고자 합니다."
         />
         <link rel="icon" href={ICON} type="image/png" />
-        <link
-          data-react-helmet="true"
-          rel="stylesheet"
-          href="https://cdn.rawgit.com/mfd/09b70eb47474836f25a21660282ce0fd/raw/e06a670afcb2b861ed2ac4a1ef752d062ef6b46b/Gilroy.css"
-        />
-        <link
-          href="//spoqa.github.io/spoqa-han-sans/css/SpoqaHanSans-kr.css"
-          rel="stylesheet"
-          type="text/css"
-        />
-        <link
-          href="//spoqa.github.io/spoqa-han-sans/css/SpoqaHanSans-jp.css"
-          rel="stylesheet"
-          type="text/css"
-        />
       </Head>
       <ThemeProvider theme={theme}>
         <Component {...pageProps} />

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -12,7 +12,6 @@ class MashUpDocument extends Document {
       <Html lang="ko">
         <Head title="Mash-up | IT 연합 동아리">
           <link
-            data-react-helmet="true"
             rel="stylesheet"
             href="https://cdn.rawgit.com/mfd/09b70eb47474836f25a21660282ce0fd/raw/e06a670afcb2b861ed2ac4a1ef752d062ef6b46b/Gilroy.css"
           />

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,5 +1,5 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document';
-import React from "react";
+import React from 'react';
 
 class MashUpDocument extends Document {
   static async getInitialProps(ctx) {
@@ -10,16 +10,30 @@ class MashUpDocument extends Document {
   render() {
     return (
       <Html lang="ko">
-        <Head title="Mash-up | IT 연합 동아리"/>
+        <Head title="Mash-up | IT 연합 동아리">
+          <link
+            data-react-helmet="true"
+            rel="stylesheet"
+            href="https://cdn.rawgit.com/mfd/09b70eb47474836f25a21660282ce0fd/raw/e06a670afcb2b861ed2ac4a1ef752d062ef6b46b/Gilroy.css"
+          />
+          <link
+            href="https://spoqa.github.io/spoqa-han-sans/css/SpoqaHanSans-kr.css"
+            rel="stylesheet"
+          />
+          <link
+            href="https://spoqa.github.io/spoqa-han-sans/css/SpoqaHanSans-jp.css"
+            rel="stylesheet"
+          />
+        </Head>
         <body>
-        <div className="container">
-          <Main />
-        </div>
-        <NextScript />
-        <div id="modal-root"/>
+          <div className="container">
+            <Main />
+          </div>
+          <NextScript />
+          <div id="modal-root" />
         </body>
       </Html>
-    )
+    );
   }
 }
 


### PR DESCRIPTION
## 변경사항
Next 공식문서의 내용에 따라서 이슈가 될만한 폰트 로딩부 위치를 이동 시켜주었습니다.
https://nextjs.org/docs/messages/no-stylesheets-in-head-component