### PR TITLE
Header 컴포넌트 개선 및 RecruitBanner 제거

### DIFF
--- a/src/components/LinkTo/index.tsx
+++ b/src/components/LinkTo/index.tsx
@@ -1,0 +1,20 @@
+import Link from 'next/link';
+import { ReactNode, AnchorHTMLAttributes } from 'react';
+
+interface LinkToProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
+  href: string;
+  children: ReactNode;
+  className?: string;
+}
+
+const LinkTo = ({ href, children, className = '', ...rest }: LinkToProps) => {
+  return (
+    <Link href={href} passHref>
+      <a href={href} className={className} {...rest}>
+        {children}
+      </a>
+    </Link>
+  );
+};
+
+export default LinkTo;

--- a/src/styles/reset.ts
+++ b/src/styles/reset.ts
@@ -134,7 +134,6 @@ export const resetCss = css`
 
   body {
     color: #ffffff;
-    font-family: 'Spoqa Han Sans', 'Spoqa Han Sans JP', Sans-serif;
     line-height: 1.15;
     background-color: #000000;
     -webkit-font-smoothing: antialiased;
@@ -149,6 +148,7 @@ export const resetCss = css`
   body *::before,
   body *::after {
     box-sizing: border-box;
+    font-family: 'Spoqa Han Sans', 'Spoqa Han Sans JP', Sans-serif;
   }
 
   a {

--- a/src/views/MainPage/Header/index.tsx
+++ b/src/views/MainPage/Header/index.tsx
@@ -7,7 +7,6 @@ import IMG_LOGO_TITLE from '@resources/svg/logo-title.svg';
 import { collectGaEvent } from '@utils/google';
 import LinkTo from '@components/LinkTo';
 import S from './styles.module.scss';
-import RecruitingBanner from '../RecruitingBanner';
 
 const useAnimatedHeader = () => {
   const [isVisible, setIsVisible] = useState(true);
@@ -92,8 +91,7 @@ const Header = () => {
             JOIN US! →
           </a>
         </div>
-      </div>{' '}
-      <RecruitingBanner />
+      </div>
     </motion.div>
   );
 };

--- a/src/views/MainPage/Header/index.tsx
+++ b/src/views/MainPage/Header/index.tsx
@@ -5,6 +5,7 @@ import cc from 'classcat';
 import IMG_LOGO from '@resources/images/logo.png';
 import IMG_LOGO_TITLE from '@resources/svg/logo-title.svg';
 import { collectGaEvent } from '@utils/google';
+import LinkTo from '@components/LinkTo';
 import S from './styles.module.scss';
 import RecruitingBanner from '../RecruitingBanner';
 
@@ -49,27 +50,39 @@ const Header = () => {
       animate={{ y: isVisible ? '0%' : '-100%' }}
     >
       <div className={S.Header}>
-        <a className={S.logo} href="/">
-          <img className={S.LogoImage} src={IMG_LOGO} alt="매쉬업 로고" width={32} height={32} />
-          <img className={S.LogoImage} src={IMG_LOGO_TITLE} alt="매쉬업 로고" />
-        </a>
+        <LinkTo href="/" className={S.logo}>
+          <img className={S.LogoImage} src={IMG_LOGO} alt="" width={32} height={32} />
+          <img className={S.LogoImage} src={IMG_LOGO_TITLE} alt="Mash Up" />
+        </LinkTo>
         <div className={S.menu}>
-          <a className={S.MenuItem} href="#" onClick={(event) => onNavigateTo(event, 'program')}>
-            program
-          </a>
-          <a className={S.MenuItem} href="#" onClick={(event) => onNavigateTo(event, 'team')}>
-            team
-          </a>
-          <a className={S.MenuItem} href="#" onClick={(event) => onNavigateTo(event, 'works')}>
-            works
-          </a>
-          <a
+          <button
+            type="button"
             className={S.MenuItem}
-            href="#"
+            onClick={(event) => onNavigateTo(event, 'program')}
+          >
+            program
+          </button>
+          <button
+            type="button"
+            className={S.MenuItem}
+            onClick={(event) => onNavigateTo(event, 'team')}
+          >
+            team
+          </button>
+          <button
+            type="button"
+            className={S.MenuItem}
+            onClick={(event) => onNavigateTo(event, 'works')}
+          >
+            works
+          </button>
+          <button
+            type="button"
+            className={S.MenuItem}
             onClick={(event) => onNavigateTo(event, 'partnership')}
           >
             partners
-          </a>
+          </button>
           <a
             className={S.MenuButton}
             href="https://recruit.mash-up.kr"

--- a/src/views/MainPage/Header/styles.module.scss
+++ b/src/views/MainPage/Header/styles.module.scss
@@ -48,7 +48,6 @@ $offset-y: 50px;
   .MenuItem {
     padding: 0;
     font-size: 16px;
-    // font-family: inherit;
     font-weight: bold;
     color: $page-text-first-color;
     background: transparent;

--- a/src/views/MainPage/Header/styles.module.scss
+++ b/src/views/MainPage/Header/styles.module.scss
@@ -33,7 +33,7 @@ $offset-y: 50px;
     margin-top: 8px;
   }
 
-  a {
+  button {
     font-size: 16px;
     font-weight: 600;
     &:not(:last-child) {
@@ -46,10 +46,13 @@ $offset-y: 50px;
   }
 
   .MenuItem {
+    padding: 0;
     font-size: 16px;
+    // font-family: inherit;
     font-weight: bold;
     color: $page-text-first-color;
-    text-decoration: none;
+    background: transparent;
+    border: 0;
   }
 
   .menuBtn {


### PR DESCRIPTION
## 변경사항
- Header 컴포넌트 내부에 사용되고 있는 navigator에서 button의 역할로 사용되지만 a태그로 정의되어있던것들을 button태그로 수정해주었습니다.
- Mash-Up 로고의 태그가 a태그로 되어있어 이것을 Link컴포넌트로 변경해주었습니다. 이 과정에서 LinkTo 컴포넌트가 className props를 받지 못하게끔 정의되어있어 Link태그를 랩핑한 LinkTo 컴포넌트를 정의해 사용하였습니다.
- 13기 모집기간이 종료되어 Header컴포넌트에서 렌더링 되고 있는 RecruitBanner를 제거해주었습니다.